### PR TITLE
Initialize NestJS + Vite skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Because dependencies are not installed in this environment, run the following co
 ```bash
 # install backend dependencies
 cd backend && npm install
+# install the default Express adapter
+npm install @nestjs/platform-express
 # run the backend
 npm start
 ```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# codex-test01
+# Release Management System
+
+This repository contains a minimal setup for a release management system using **NestJS** for the backend and **Vite** with **React**, **Tailwind CSS**, and **shadcn/ui** for the frontend.
+
+## Structure
+
+- `backend/` – NestJS application
+- `frontend/` – React application bootstrapped with Vite
+
+## Development
+
+Because dependencies are not installed in this environment, run the following commands locally after cloning the repository:
+
+```bash
+# install backend dependencies
+cd backend && npm install
+# run the backend
+npm start
+```
+
+```bash
+# in another terminal, install frontend dependencies
+cd frontend && npm install
+# start the frontend in dev mode
+npm run dev
+```
+
+The frontend expects Tailwind and shadcn/ui packages. Install them as needed using npm.

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,8 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "@nestjs/platform-express": "^10.0.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "release-management-backend",
+  "version": "0.1.0",
+  "scripts": {
+    "start": "ts-node src/main.ts"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.0.4"
+  }
+}

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { AppService } from './app.service';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  getHello(): string {
+    return this.appService.getHello();
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+
+@Module({
+  imports: [],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {}

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppService {
+  getHello(): string {
+    return 'Hello World!';
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": false,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2017",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "./",
+    "incremental": true
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Release Management System</title>
+    <link rel="stylesheet" href="/src/index.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "release-management-frontend",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.14",
+    "tailwindcss": "^3.3.5",
+    "typescript": "^5.0.4",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import './index.css';
+
+function App() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Release Management System</h1>
+      <p className="mt-2 text-gray-600">Welcome to your new project.</p>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{"path": "./tsconfig.node.json"}]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "release-management-system",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "test": "echo \"No tests specified\""
+  }
+}


### PR DESCRIPTION
## Summary
- add NestJS backend skeleton
- add React/Vite frontend with TailwindCSS config
- document setup in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848568a1940832e944da301f4c93008